### PR TITLE
Bump requests from 2.24 to 2.32.4

### DIFF
--- a/web-tools/e-manuscripta-access/requirements.txt
+++ b/web-tools/e-manuscripta-access/requirements.txt
@@ -1,5 +1,5 @@
 pandas==1.1.3
-requests==2.24
+requests==2.32.4
 polymatheia==0.3.1
 beautifulsoup4==4.9.3
 lxml==4.9.1


### PR DESCRIPTION
Hallo @k-woitas

Ich sehe, dass dependabot bei 3 Security Alerts bei der Erstellung eines PRs «hängt»:

https://github.com/ub-unibe-ch/ds-pytools/security/dependabot

Es geht dabei immer um die dependency «requests» für e-manuscripta-access.
Nehme an, dass die sich gegenseitig Blockieren (verschiedene vulnerabilities, gepatchte versionen).

Ich habe dir hier einen PR erstellt, welche die grösste der gepatchten Versions-Angaben verwendet (2.32.4).
Gehe davon aus, dass Python resp. die dependencies auch [semver](https://semver.org) verwenden - dann sollte das Skript mit diesem minor update weiterhin funktionieren.

